### PR TITLE
Fix for #53

### DIFF
--- a/Plugin/DS4H-Image-Alignment/src/main/java/DS4H/AboutDialog.java
+++ b/Plugin/DS4H-Image-Alignment/src/main/java/DS4H/AboutDialog.java
@@ -161,15 +161,11 @@ public class AboutDialog extends JDialog {
         panel2.setAlignmentY(0.5f);
         panel1.add(panel2, BorderLayout.CENTER);
         final JLabel label1 = new JLabel();
-      //  Font label1Font = this.$$$getFont$$$(null, -1, 10, label1.getFont());
-    //    if (label1Font != null) label1.setFont(label1Font);
         label1.setHorizontalAlignment(10);
         label1.setText("Copyright (©) 2019 Data Science for Health (DS4H) Group. All rights reserved");
         panel2.add(label1, BorderLayout.NORTH);
         final JLabel label2 = new JLabel();
         label2.setAlignmentY(1.0f);
-      //  Font label2Font = this.$$$getFont$$$(null, -1, 10, label2.getFont());
-     //   if (label2Font != null) label2.setFont(label2Font);
         label2.setHorizontalAlignment(10);
         label2.setText("License: GNU General Public License version 3");
         panel2.add(label2, BorderLayout.SOUTH);
@@ -231,8 +227,6 @@ public class AboutDialog extends JDialog {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         pnl_title.add(lbl_version, gbc);
         final JLabel label3 = new JLabel();
-      //  Font label3Font = this.$$$getFont$$$("Droid Sans Mono", Font.PLAIN, 20, label3.getFont());
-      //  if (label3Font != null) label3.setFont(label3Font);
         label3.setForeground(new Color(-16777216));
         label3.setText("DS4H Image Aligment");
         gbc = new GridBagConstraints();
@@ -321,25 +315,6 @@ public class AboutDialog extends JDialog {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         pnl_authors.add(lbl_author1, gbc);
     }
-
-    /**
-     * @noinspection ALL
-     */
-/*    private Font $$$getFont$$$(String fontName, int style, int size, Font currentFont) {
-        if (currentFont == null) return null;
-        String resultName;
-        if (fontName == null) {
-            resultName = currentFont.getName();
-        } else {
-            Font testFont = new Font(fontName, Font.PLAIN, 10);
-            if (testFont.canDisplay('a') && testFont.canDisplay('1')) {
-                resultName = fontName;
-            } else {
-                resultName = currentFont.getName();
-            }
-        }
-        return new Font(resultName, style >= 0 ? style : currentFont.getStyle(), size >= 0 ? size : currentFont.getSize());
-    }*/
 
     /**
      * @noinspection ALL

--- a/Plugin/DS4H-Image-Alignment/src/main/java/DS4H/AboutDialog.java
+++ b/Plugin/DS4H-Image-Alignment/src/main/java/DS4H/AboutDialog.java
@@ -161,15 +161,15 @@ public class AboutDialog extends JDialog {
         panel2.setAlignmentY(0.5f);
         panel1.add(panel2, BorderLayout.CENTER);
         final JLabel label1 = new JLabel();
-        Font label1Font = this.$$$getFont$$$(null, -1, 10, label1.getFont());
-        if (label1Font != null) label1.setFont(label1Font);
+      //  Font label1Font = this.$$$getFont$$$(null, -1, 10, label1.getFont());
+    //    if (label1Font != null) label1.setFont(label1Font);
         label1.setHorizontalAlignment(10);
         label1.setText("Copyright (©) 2019 Data Science for Health (DS4H) Group. All rights reserved");
         panel2.add(label1, BorderLayout.NORTH);
         final JLabel label2 = new JLabel();
         label2.setAlignmentY(1.0f);
-        Font label2Font = this.$$$getFont$$$(null, -1, 10, label2.getFont());
-        if (label2Font != null) label2.setFont(label2Font);
+      //  Font label2Font = this.$$$getFont$$$(null, -1, 10, label2.getFont());
+     //   if (label2Font != null) label2.setFont(label2Font);
         label2.setHorizontalAlignment(10);
         label2.setText("License: GNU General Public License version 3");
         panel2.add(label2, BorderLayout.SOUTH);
@@ -231,8 +231,8 @@ public class AboutDialog extends JDialog {
         gbc.fill = GridBagConstraints.HORIZONTAL;
         pnl_title.add(lbl_version, gbc);
         final JLabel label3 = new JLabel();
-        Font label3Font = this.$$$getFont$$$("Droid Sans Mono", Font.PLAIN, 20, label3.getFont());
-        if (label3Font != null) label3.setFont(label3Font);
+      //  Font label3Font = this.$$$getFont$$$("Droid Sans Mono", Font.PLAIN, 20, label3.getFont());
+      //  if (label3Font != null) label3.setFont(label3Font);
         label3.setForeground(new Color(-16777216));
         label3.setText("DS4H Image Aligment");
         gbc = new GridBagConstraints();
@@ -325,7 +325,7 @@ public class AboutDialog extends JDialog {
     /**
      * @noinspection ALL
      */
-    private Font $$$getFont$$$(String fontName, int style, int size, Font currentFont) {
+/*    private Font $$$getFont$$$(String fontName, int style, int size, Font currentFont) {
         if (currentFont == null) return null;
         String resultName;
         if (fontName == null) {
@@ -339,7 +339,7 @@ public class AboutDialog extends JDialog {
             }
         }
         return new Font(resultName, style >= 0 ? style : currentFont.getStyle(), size >= 0 ? size : currentFont.getSize());
-    }
+    }*/
 
     /**
      * @noinspection ALL

--- a/Plugin/DS4H-Image-Alignment/src/main/java/DS4H/ImageAlignment.java
+++ b/Plugin/DS4H-Image-Alignment/src/main/java/DS4H/ImageAlignment.java
@@ -27,6 +27,7 @@ import ij.process.ColorProcessor;
 import ij.process.ImageProcessor;
 import loci.formats.UnknownFormatException;
 import org.scijava.AbstractContextual;
+import org.scijava.Context;
 import org.scijava.command.Command;
 import org.scijava.plugin.Plugin;
 
@@ -72,7 +73,7 @@ public class ImageAlignment extends AbstractContextual implements Command, OnMai
 	static private long TotalMemory = 0;
 	public static void main(final String... args) {
 		ImageJ ij = new ImageJ();
-		ij.ui().showUI();
+		ij.launch(args);
 		ImageAlignment plugin = new ImageAlignment();
 		plugin.setContext(ij.getContext());
 		plugin.run();


### PR DESCRIPTION
Issue #53 fixed. It was caused by the dialog form specifications file (.form) and the relative generated swing .java class. Probably, switching the intelliJ IDE from 2018 to the 2020 version caused this weird bug to happen. Nevertheless, the malicious code has been removed and the affected dialog (aboutDialog) seems to render the same way.